### PR TITLE
fix(insc): fix the vulnerability that could mint one more than the maximum supply limit

### DIFF
--- a/contracts/Passover.sol
+++ b/contracts/Passover.sol
@@ -35,6 +35,7 @@ contract Passover is ERC20, IERC7583, Ownable, Pausable {
   /// @param tokenId The TokenID corresponding to the transaction trail
   /// @param amount The quantity eligible for compensation
   /// @param txHash The tx hash corresponding to your compensation
+  /// @param nonce The nonce is used as a random number to increase the entropy source.
   /// @param proofs Merkle proof from backend
   function claimLossesDirect(uint256 tokenId, uint256 amount, bytes32 txHash, uint256 nonce, bytes32[] calldata proofs) public whenNotPaused {
     // merkle verify
@@ -55,6 +56,7 @@ contract Passover is ERC20, IERC7583, Ownable, Pausable {
   /// @param tokenId The TokenID corresponding to the transaction trail
   /// @param amount The quantity eligible for compensation
   /// @param txHash The tx hash corresponding to your compensation
+  /// @param nonce The nonce is used as a random number to increase the entropy source.
   /// @param proofs Merkle proof from backend
   function refund(uint256 tokenId, uint256 amount, bytes32 txHash, uint256 nonce, bytes32[] calldata proofs) public payable whenNotPaused {
     require(msg.value == amount, "The refund amount is incorrect");
@@ -83,6 +85,7 @@ contract Passover is ERC20, IERC7583, Ownable, Pausable {
   /// @param tokenId The TokenID corresponding to the transaction trail
   /// @param amount The quantity eligible for compensation
   /// @param txHash The tx hash corresponding to your compensation
+  /// @param nonce The nonce is used as a random number to increase the entropy source.
   /// @param proofs Merkle proof from backend
   function claimLossesAfterRefund(uint256 tokenId, uint256 amount, bytes32 txHash, uint256 nonce, bytes32[] calldata proofs) public whenNotPaused {
     // merkle verify

--- a/test/INSC.t.js
+++ b/test/INSC.t.js
@@ -1,3 +1,10 @@
+const {
+  loadFixture,
+} = require("@nomicfoundation/hardhat-toolbox/network-helpers");
+const { MerkleTree } = require('merkletreejs');
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
 describe("INSC+", function () {
   // We define a fixture to reuse the same setup in every test.
   // We use loadFixture to run this setup once, snapshot that state,
@@ -8,17 +15,17 @@ describe("INSC+", function () {
 
     const name = "INSC Plus";
     const symbol = "INSC+";
-    const maxSupply = 21000000;
+    const maxSupply = 3000;
     const mintLimit = 1000;
-    const tickNumberMax = 63000;
+    const tickNumberMax = 9;
     const INSC = await ethers.getContractFactory("INS20");
-    const insc = await INSC.deploy(symbol, maxSupply, mintLimit, tickNumberMax, owner.address);
+    const insc = await INSC.deploy(maxSupply, mintLimit,  owner.address);
 
     // ----------- Merkle -----------
 
     const values = [
       [user1.address, 1000],
-      [user2.address, 1000],
+      [user2.address, 1000], // test same tokenId
       [user3.address, 10000],
       [user4.address, 10001],
       [user5.address, 10002]
@@ -46,6 +53,163 @@ describe("INSC+", function () {
 
     // ----------- Merkle Over -----------
 
-    return { insc, name, symbol, owner, user1, user2, user3, user4, user5, root, values, proofs};
+    const userList = [user2, user3, user4, user5];
+    return { insc, name, symbol, maxSupply, mintLimit, tickNumberMax, owner, user1, user2, user3, user4, user5, userList, root, values, proofs};
   }
+
+  describe("Deployment", function () {
+    it("Should set the right name", async function () {
+      const { insc, name } = await loadFixture(deployINSCFixture);
+
+      expect(await insc.name()).to.equal(name);
+    });
+
+    it("Should set the right symbol", async function () {
+      const { insc, symbol } = await loadFixture(deployINSCFixture);
+
+      expect(await insc.symbol()).to.equal(symbol);
+    });
+
+    it("Should set the right maxSupply", async function () {
+      const { insc, maxSupply } = await loadFixture(deployINSCFixture);
+
+      expect(await insc.maxSupply()).to.equal(maxSupply);
+    });
+
+    it("Should set the right mintLimit", async function () {
+      const { insc, mintLimit } = await loadFixture(deployINSCFixture);
+
+      expect(await insc.mintLimit()).to.equal(mintLimit);
+    });
+
+    it("Should set the right tickNumberMax", async function () {
+      const { insc, maxSupply, mintLimit , tickNumberMax} = await loadFixture(deployINSCFixture);
+
+      expect(await insc.tickNumberMax()).to.equal(maxSupply * 3 / mintLimit).to.equal(tickNumberMax);
+    });
+
+    it("Should set the right owner", async function () {
+      const { insc, owner } = await loadFixture(deployINSCFixture);
+
+      expect(await insc.owner()).to.equal(owner.address);
+    });
+  });
+
+  describe("Inscribe", function () {
+    it("Should revert if inscribe is not open", async function () {
+      const { insc, owner, user1 , root, values, proofs} = await loadFixture(deployINSCFixture);
+
+      await insc.connect(owner).setMerkleRoot(root);
+
+      const [, tokenIdUser1] = values[0];
+      const proofUser1 = proofs[0];
+
+      await expect(insc.connect(user1).inscribe(tokenIdUser1, proofUser1)).to.be.revertedWith("Is not open");
+    });
+
+    it("Should revert if exceeded mint limit", async function () {
+      const { insc, owner, userList, maxSupply, mintLimit, root, values, proofs} = await loadFixture(deployINSCFixture);
+
+      await insc.connect(owner).setMerkleRoot(root);
+      await insc.connect(owner).openInscribe();
+      
+      for (let i = 0; i < maxSupply / mintLimit; i++) {
+        const [, tokenIdUserI] = values[i + 1];
+        const proofUserI = proofs[i + 1];
+        await insc.connect(userList[i]).inscribe(tokenIdUserI, proofUserI);
+      }
+
+      const [, tokenIdUserLast] = values[values.length - 1]
+      const proofUserLast = proofs[proofs.length - 1];
+      await expect(insc.connect(userList[userList.length - 1]).inscribe(tokenIdUserLast, proofUserLast)).to.be.revertedWith("Exceeded mint limit");
+    });
+
+    it("Should revert if msg.sender is wrong", async function () {
+      const { insc, owner, user3 , root, values, proofs} = await loadFixture(deployINSCFixture);
+
+      await insc.connect(owner).setMerkleRoot(root);
+      await insc.connect(owner).openInscribe();
+
+      const [, tokenIdUser1] = values[0];
+      const proofUser1 = proofs[0];
+
+      await expect(insc.connect(user3).inscribe(tokenIdUser1, proofUser1)).to.be.revertedWith("Merkle verification failed");
+    });
+
+    it("Should revert if tokenId is wrong", async function () {
+      const { insc, owner, user1 , root, values, proofs} = await loadFixture(deployINSCFixture);
+
+      await insc.connect(owner).setMerkleRoot(root);
+      await insc.connect(owner).openInscribe();
+
+      const [, tokenIdUser1] = values[0];
+      const proofUser1 = proofs[0];
+
+      await expect(insc.connect(user1).inscribe(tokenIdUser1 + 1, proofUser1)).to.be.revertedWith("Merkle verification failed");
+    });
+
+    it("Should revert if proofs are wrong", async function () {
+      const { insc, owner, user1 , root, values, proofs} = await loadFixture(deployINSCFixture);
+
+      await insc.connect(owner).setMerkleRoot(root);
+      await insc.connect(owner).openInscribe();
+
+      const [, tokenIdUser1] = values[0];
+      const proofUser1 = proofs[0];
+
+      await expect(insc.connect(user1).inscribe(tokenIdUser1, proofs[1])).to.be.revertedWith("Merkle verification failed");
+    });
+
+    it("Should revert if use same proofs twice", async function () {
+      const { insc, owner, user1 , root, values, proofs} = await loadFixture(deployINSCFixture);
+
+      await insc.connect(owner).setMerkleRoot(root);
+      await insc.connect(owner).openInscribe();
+
+      const [, tokenIdUser1] = values[0];
+      const proofUser1 = proofs[0];
+
+      await insc.connect(user1).inscribe(tokenIdUser1, proofUser1);
+      await expect(insc.connect(user1).inscribe(tokenIdUser1, proofUser1)).to.be.revertedWithCustomError(insc, "ERC721InvalidSender");
+    });
+
+    it("Should revert if two uses inscribe same tokenId", async function () {
+      const { insc, owner, user1, user2 , root, values, proofs} = await loadFixture(deployINSCFixture);
+
+      await insc.connect(owner).setMerkleRoot(root);
+      await insc.connect(owner).openInscribe();
+
+      const [, tokenIdUser1] = values[0];
+      const proofUser1 = proofs[0];
+      await insc.connect(user1).inscribe(tokenIdUser1, proofUser1);
+
+      // user2 has the same tokenID proofs
+      const [, tokenIdUser2] = values[1];
+      const proofUser2 = proofs[1];
+      await expect(insc.connect(user2).inscribe(tokenIdUser2, proofUser2)).to.be.revertedWithCustomError(insc, "ERC721InvalidSender");
+    });
+
+    it("Should succeed if all conditions are met", async function () {
+      const { insc, owner, user1, root, values, proofs, mintLimit} = await loadFixture(deployINSCFixture);
+
+      await insc.connect(owner).setMerkleRoot(root);
+      await insc.connect(owner).openInscribe();
+
+      const [, tokenIdUser1] = values[0];
+      const proofUser1 = proofs[0];
+      // event check
+      const hexString = '0x' + Buffer.from('data:text/plain;charset=utf-8,{"p":"ins-20","op":"mint","tick":"INSC+","amt":"1000"}', 'utf8').toString('hex');
+      await expect(insc.connect(user1).inscribe(tokenIdUser1, proofUser1)).to.emit(insc, "Inscribe").withArgs(tokenIdUser1, hexString);
+
+      // data status check
+      expect(await insc.balanceOf(user1.address)).to.equal(1);
+      expect(await insc.tickNumber()).to.equal(1);
+      expect(await insc.ownerOf(tokenIdUser1)).to.equal(user1.address);
+      expect(await insc.totalSupply()).to.equal(mintLimit * 1);
+    });
+
+    it("For production environment", async function () {
+      
+    });
+  });
 })

--- a/test/Passover.js
+++ b/test/Passover.js
@@ -1,5 +1,4 @@
 const {
-  time,
   loadFixture,
 } = require("@nomicfoundation/hardhat-toolbox/network-helpers");
 const { anyValue } = require("@nomicfoundation/hardhat-chai-matchers/withArgs");
@@ -293,6 +292,10 @@ describe("Passover", function () {
       expect(await passover.balanceOf(user5.address)).to.equal(amountUser5);
       expect(await passover.totalSupply()).to.equal(amountUser4 + amountUser5);
     });
+
+    it("For production environment", async function () {
+      
+    });
   });
 
   describe("Refund", function () {
@@ -433,6 +436,10 @@ describe("Passover", function () {
 
       expect(vaultBalanceAfter).to.equal(vaultBalanceBefore + addedBigNumber);
     });
+
+    it("For production environment", async function () {
+      
+    });
   });
 
   describe("ClaimLossesAfterRefund", function () {
@@ -564,6 +571,10 @@ describe("Passover", function () {
       expect(await passover.balanceOf(user4.address)).to.equal(amountUser4);
       expect(await passover.balanceOf(user5.address)).to.equal(amountUser5);
       expect(await passover.totalSupply()).to.equal(amountUser4 + amountUser5);
+    });
+
+    it("For production environment", async function () {
+      
     });
   });
 });


### PR DESCRIPTION
- Since the tickNumber starts from 0 for the check, the maximum supply check of <= should be changed to <
- In order to adhere to the security principle of placing the most important variable changes last, the code related to 'to' in 'recordSlot' has been moved to the front here
- Completed the unit testing for the inscribe function.